### PR TITLE
Fix typo in modbus baud rate comments

### DIFF
--- a/configuration_examples/LP_example_multi-node_YamBMS_modbus_client.yaml
+++ b/configuration_examples/LP_example_multi-node_YamBMS_modbus_client.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/configuration_examples/LP_example_multi-node_YamBMS_modbus_server_1.yaml
+++ b/configuration_examples/LP_example_multi-node_YamBMS_modbus_server_1.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/configuration_examples/LP_example_multi-node_YamBMS_modbus_server_2.yaml
+++ b/configuration_examples/LP_example_multi-node_YamBMS_modbus_server_2.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/configuration_examples/RP_example_multi-node_YamBMS_modbus_client.yaml
+++ b/configuration_examples/RP_example_multi-node_YamBMS_modbus_client.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/configuration_examples/RP_example_multi-node_YamBMS_modbus_server_1.yaml
+++ b/configuration_examples/RP_example_multi-node_YamBMS_modbus_server_1.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/configuration_examples/RP_example_multi-node_YamBMS_modbus_server_2.yaml
+++ b/configuration_examples/RP_example_multi-node_YamBMS_modbus_server_2.yaml
@@ -25,7 +25,7 @@
 
 substitutions:
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
 

--- a/packages/yambms/yambms.yaml
+++ b/packages/yambms/yambms.yaml
@@ -40,7 +40,7 @@ esphome:
           if (${yambms_battery_chemistry} == 1) // LFP
           {
             // LFP
-            id(${yambms_id}_cell_mominal_v) = 3.20;
+            id(${yambms_id}_cell_nominal_v) = 3.20;
             id(${yambms_id}_cell_min_charge_v) = 3.37; // Fully charged at rest
             id(${yambms_id}_cell_max_charge_v) = 3.65;
             id(${yambms_id}_cell_max_discharge_v) = 3.00; // Not used
@@ -48,7 +48,7 @@ esphome:
           else if (${yambms_battery_chemistry} == 2) // Li-ion
           {
             // Li-ion
-            id(${yambms_id}_cell_mominal_v) = 3.60;
+            id(${yambms_id}_cell_nominal_v) = 3.60;
             id(${yambms_id}_cell_min_charge_v) = 3.90;
             id(${yambms_id}_cell_max_charge_v) = 4.20;
             id(${yambms_id}_cell_max_discharge_v) = 3.20; // Not used
@@ -56,7 +56,7 @@ esphome:
           else if (${yambms_battery_chemistry} == 3) // LTO
           {
             // LTO
-            id(${yambms_id}_cell_mominal_v) = 2.40;
+            id(${yambms_id}_cell_nominal_v) = 2.40;
             id(${yambms_id}_cell_min_charge_v) = 2.55; // Fully charged at rest
             id(${yambms_id}_cell_max_charge_v) = 2.85;
             id(${yambms_id}_cell_max_discharge_v) = 2.00; // Not used
@@ -69,7 +69,7 @@ esphome:
           id(${yambms_id}_float_voltage).traits.set_min_value(round(cell_count * (id(${yambms_id}_cell_min_charge_v) - 0.1) * 10) / 10);
           id(${yambms_id}_float_voltage).traits.set_max_value(round(cell_count * (id(${yambms_id}_cell_min_charge_v) + 0.1) * 10) / 10);
           // Rebulk V.
-          id(${yambms_id}_rebulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_cell_mominal_v) * 10) / 10);
+          id(${yambms_id}_rebulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_cell_nominal_v) * 10) / 10);
           id(${yambms_id}_rebulk_voltage).traits.set_max_value(round(cell_count * id(${yambms_id}_cell_min_charge_v) * 10) / 10);
 
 globals:
@@ -95,7 +95,7 @@ globals:
   - id: ${yambms_id}_canbus_protocol
     type: std::string
     restore_value: no
-  - id: ${yambms_id}_cell_mominal_v
+  - id: ${yambms_id}_cell_nominal_v
     type: float
     restore_value: no
     initial_value: '0.0'

--- a/yambms_config.yaml
+++ b/yambms_config.yaml
@@ -22,6 +22,6 @@ substitutions:
   # | Multi-Node Modbus Settings           |
   # +--------------------------------------+
   modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
-  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_baud_rate: '19200' # 9600 / 19200 / 115200
   modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
   modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending


### PR DESCRIPTION
## Summary
- fix 11520 -> 115200 in example configs
- rename `cell_mominal_v` to `cell_nominal_v` in `yambms.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e279ab08832db99ab278b3194db3