### PR TITLE
Fix docs typo and update DEYE CAN sensors

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,21 @@
+name: yamllint
+
+on:
+  push:
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+  pull_request:
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yamllint
+        run: sudo apt-get update && sudo apt-get install -y yamllint
+      - name: Run yamllint
+        run: yamllint .

--- a/documents/README/BMS_JK-B.md
+++ b/documents/README/BMS_JK-B.md
@@ -23,7 +23,7 @@ The `GPS` port sometimes called `RS485` is not an `RS485` port but `3V3 UART-TTL
 │ O   O   O   O  │
 │GND  RX  TX VBAT│ 
 └────────────────┘
-  │   │   │   └ VBAT is full battery volatge eg. 56V (possible to use it via an isolated DC-DC converter)
+  │   │   │   └ VBAT is full battery voltage eg. 56V (possible to use it via an isolated DC-DC converter)
   │   │   └──── TX  to TTL-isolator AI (input)
   │   └──────── RX  to TTL-isolator AO (output)
   └──────────── GND to TTL-isolator GND

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -120,7 +120,7 @@ canbus:
         - lambda: |-
             float charged = ((x[3] << 24) | (x[2] << 16) | (x[1] << 8) | x[0]) / 1000.0;
             id(bms${bms_id}_charged).publish_state(charged);
-            float discharged = ((x[7] << 24) | (x[6] << 16) | (x[5] << 8) | x[5]) / 1000.0;
+            float discharged = ((x[7] << 24) | (x[6] << 16) | (x[5] << 8) | x[4]) / 1000.0;
             id(bms${bms_id}_discharged).publish_state(discharged);
   #          ESP_LOGI("canid 0x550:", "%.3f kWh, %.3f kWh", charged, discharged );
   #          ESP_LOGI("canid 0x550:", "%02x %02x %02x %02x %02x %02x %02x %02x", x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]);

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -86,7 +86,7 @@ canbus:
         - lambda: |-
             float charged = ((x[3] << 24) | (x[2] << 16) | (x[1] << 8) | x[0]) / 1000.0;
             id(bms${bms_id}_charged).publish_state(charged);
-            float discharged = ((x[7] << 24) | (x[6] << 16) | (x[5] << 8) | x[5]) / 1000.0;
+            float discharged = ((x[7] << 24) | (x[6] << 16) | (x[5] << 8) | x[4]) / 1000.0;
             id(bms${bms_id}_discharged).publish_state(discharged);
             
 binary_sensor:


### PR DESCRIPTION
## Summary
- fix typo in JK-B documentation
- correct discharged energy byte order
- add yamllint GitHub Actions workflow

## Testing
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845e279db10832da9675c6db21cc832