### PR TITLE
Optimize display update timing

### DIFF
--- a/packages/board/board_ESP32-S3_AtomS3.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3.yaml
@@ -20,6 +20,7 @@
 substitutions:
   board_chip: "ESP32-S3"
   board_name: "Atom S3"
+  display_update_interval: "500ms"
   # Interfaces GPIOs
   # uart_esp_1 (Grove port)
   tx_pin_1: '2'
@@ -145,6 +146,6 @@ display:
     offset_height: 2
     offset_width: 1
     eightbitcolor: true
-    update_interval: 1s
+    update_interval: ${display_update_interval}
     data_rate: 40Mhz
     rotation: ${display_rotation}

--- a/packages/board/board_ESP32-S3_AtomS3R.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3R.yaml
@@ -20,6 +20,7 @@
 substitutions:
   board_chip: "ESP32-S3"
   board_name: "Atom S3R"
+  display_update_interval: "500ms"
   # Interfaces GPIOs
   # uart_esp_1 (Grove port)
   tx_pin_1: '2'
@@ -170,6 +171,6 @@ display:
     offset_height: 2
     offset_width: 1
     eightbitcolor: true
-    update_interval: 1s
+    update_interval: ${display_update_interval}
     data_rate: 40Mhz
     rotation: ${display_rotation}

--- a/packages/board/board_ESP32-S3_AtomS3_WOD.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3_WOD.yaml
@@ -20,6 +20,7 @@
 substitutions:
   board_chip: "ESP32-S3"
   board_name: "Atom S3"
+  display_update_interval: "500ms"
   # Interfaces GPIOs
   # uart_esp_1 (Grove port)
   tx_pin_1: '2'
@@ -145,6 +146,6 @@ display:
     offset_height: 2
     offset_width: 1
     eightbitcolor: true
-    update_interval: 1s
+    update_interval: ${display_update_interval}
     data_rate: 40Mhz
     rotation: ${display_rotation}


### PR DESCRIPTION
## Summary
- allow custom display refresh interval for Atom S3 boards
- refresh Atom S3 displays every 500ms for smoother output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ed96871c832dbaf074f4ae770fef