### PR TITLE
Add remaining time sensor

### DIFF
--- a/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
+++ b/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
@@ -77,23 +77,6 @@ sensor:
       name: ${name} ${shunt_name} Discharged Energy
     battery_capacity_ah:
       name: ${name} ${shunt_name} Battery Capacity
-    remaining_time:
-      name: ${name} ${shunt_name} Remaining Time
-      unit_of_measurement: h
-      device_class: duration
-      accuracy_decimals: 1
-      lambda: |-
-        if (isnan(id(shunt${shunt_id}_power).state) ||
-            isnan(id(shunt${shunt_id}_voltage).state) ||
-            isnan(id(shunt${shunt_id}_battery_capacity_ah).state) ||
-            isnan(id(shunt${shunt_id}_soc).state) ||
-            id(shunt${shunt_id}_power).state == 0) {
-          return NAN;
-        }
-        float remaining_ah = id(shunt${shunt_id}_battery_capacity_ah).state * id(shunt${shunt_id}_soc).state / 100.0;
-        float power = fabs(id(shunt${shunt_id}_power).state);
-        float voltage = id(shunt${shunt_id}_voltage).state;
-        return (remaining_ah * voltage) / power;
     soc100_voltage:
       name: ${name} ${shunt_name} SoC 100% Voltage
     soc0_voltage:
@@ -112,3 +95,23 @@ sensor:
       name: ${name} ${shunt_name} Over Temperature Protection
     under_temperature_protection:
       name: ${name} ${shunt_name} Under Temperature Protection
+
+  - platform: template
+    id: shunt${shunt_id}_remaining_time
+    name: ${name} ${shunt_name} Remaining Time
+    update_interval: ${shunt_update_interval}
+    unit_of_measurement: h
+    device_class: duration
+    accuracy_decimals: 1
+    lambda: |-
+      if (isnan(id(shunt${shunt_id}_power).state) ||
+          isnan(id(shunt${shunt_id}_voltage).state) ||
+          isnan(id(shunt${shunt_id}_battery_capacity_ah).state) ||
+          isnan(id(shunt${shunt_id}_soc).state) ||
+          id(shunt${shunt_id}_power).state == 0) {
+        return NAN;
+      }
+      float remaining_ah = id(shunt${shunt_id}_battery_capacity_ah).state * id(shunt${shunt_id}_soc).state / 100.0;
+      float power = fabs(id(shunt${shunt_id}_power).state);
+      float voltage = id(shunt${shunt_id}_voltage).state;
+      return (remaining_ah * voltage) / power;

--- a/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
+++ b/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
@@ -77,6 +77,23 @@ sensor:
       name: ${name} ${shunt_name} Discharged Energy
     battery_capacity_ah:
       name: ${name} ${shunt_name} Battery Capacity
+    remaining_time:
+      name: ${name} ${shunt_name} Remaining Time
+      unit_of_measurement: h
+      device_class: duration
+      accuracy_decimals: 1
+      lambda: |-
+        if (isnan(id(shunt${shunt_id}_power).state) ||
+            isnan(id(shunt${shunt_id}_voltage).state) ||
+            isnan(id(shunt${shunt_id}_battery_capacity_ah).state) ||
+            isnan(id(shunt${shunt_id}_soc).state) ||
+            id(shunt${shunt_id}_power).state == 0) {
+          return NAN;
+        }
+        float remaining_ah = id(shunt${shunt_id}_battery_capacity_ah).state * id(shunt${shunt_id}_soc).state / 100.0;
+        float power = fabs(id(shunt${shunt_id}_power).state);
+        float voltage = id(shunt${shunt_id}_voltage).state;
+        return (remaining_ah * voltage) / power;
     soc100_voltage:
       name: ${name} ${shunt_name} SoC 100% Voltage
     soc0_voltage:


### PR DESCRIPTION
## Summary
- add `remaining_time` template sensor to Junctek shunt package

## Testing
- `yamllint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845efad0e1c832d8a990fdbb2baed5c