### PR TITLE
Fix state_class for BMS charging cycle sensor

### DIFF
--- a/packages/bms/bms_charging_cycles_base.yaml
+++ b/packages/bms/bms_charging_cycles_base.yaml
@@ -19,6 +19,7 @@ sensor:
     id: bms${bms_id}_charging_cycles
     update_interval: ${bms_update_interval}
     accuracy_decimals: 0
+    state_class: total
     icon: mdi:counter
     filters:
       - or:


### PR DESCRIPTION
## Summary
- restore `state_class` on the charging cycle sensor and use `total`

## Testing
- `yamllint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848751773ac832d8d639a6f1f235558